### PR TITLE
Fix for "Null check opeator used on null value" exception.

### DIFF
--- a/lib/src/responsive_datatable.dart
+++ b/lib/src/responsive_datatable.dart
@@ -379,6 +379,7 @@ class _ResponsiveDatatableState extends State<ResponsiveDatatable> {
             ),
           ),
           if (widget.isExpandRows &&
+              widget.expanded != null &&
               widget.expanded![index] &&
               widget.dropContainer != null)
             widget.dropContainer!(data)


### PR DESCRIPTION
I encountered this exception when dynamically building data table headers and the data list. The headers were defined using the bare minimum text and value properties, and this error cropped up when assigning them to the table. The .expanded property was a null value and threw an exception.